### PR TITLE
 add Netfilter queue maxlen

### DIFF
--- a/osfooler_ng/module_p0f.py
+++ b/osfooler_ng/module_p0f.py
@@ -57,7 +57,7 @@ class p0fKnowledgeBase(KnowledgeBase):
             for l in f:
                 if l[0] in ["#","\n"]:
                     continue
-                l = tuple(l.split(":"))
+                l = tuple(l.strip().split(":"))
                 if len(l) < 8:
                     continue
                 def a2i(x):
@@ -68,7 +68,7 @@ class p0fKnowledgeBase(KnowledgeBase):
                 #if li[0] not in self.ttl_range:
                 #    self.ttl_range.append(li[0])
                 #    self.ttl_range.sort()
-                self.base.append((l[0], li[0], li[1], li[2], l[4], l[5], l[6], l[7][:-1]))
+                self.base.append((l[0], li[0], li[1], li[2], l[4], l[5], l[6], l[7]))
         except:
             warning("Can't parse p0f database (new p0f version ?)")
             self.base = None

--- a/osfooler_ng/osfooler_ng.py
+++ b/osfooler_ng/osfooler_ng.py
@@ -954,7 +954,7 @@ def main():
   procs = []
   # nmap mode
   if opts.os:  
-    os.system("iptables -A INPUT -j NFQUEUE --queue-num %s" % q_num0) 
+    os.system("iptables -A INPUT -t mangle -j NFQUEUE --queue-num %s" % q_num0) 
     proc = Process(target=init,args=(q_num0,))
     procs.append(proc)
     proc.start() 
@@ -962,7 +962,7 @@ def main():
   if (opts.osgenre):
     global home_ip
     home_ip = get_ip_address(interface)  
-    os.system("iptables -A OUTPUT -p TCP --syn -j NFQUEUE --queue-num %s" % q_num1) 
+    os.system("iptables -A OUTPUT -t mangle -p TCP --syn -j NFQUEUE --queue-num %s" % q_num1) 
     proc = Process(target=init,args=(q_num1,))
     procs.append(proc)
     proc.start() 
@@ -974,18 +974,18 @@ def main():
       print
       # Flush all iptabels rules
       if (q_num0 >= 0):
-        os.system("iptables -D INPUT -j NFQUEUE --queue-num %s" % q_num0) 
+        os.system("iptables -D INPUT -t mangle -j NFQUEUE --queue-num %s" % q_num0) 
       if (q_num1 >= 1):
-        os.system("iptables -D OUTPUT -p TCP --syn -j NFQUEUE --queue-num %s" % q_num1) 
+        os.system("iptables -D OUTPUT -t mangle -p TCP --syn -j NFQUEUE --queue-num %s" % q_num1) 
       print " [+] Active queues removed"
       print " [+] Exiting OSfooler..." 
   except KeyboardInterrupt:
       print
       # Flush all iptabels rules
       if (q_num0 >= 0):
-        os.system("iptables -D INPUT -j NFQUEUE --queue-num %s" % q_num0) 
+        os.system("iptables -D INPUT -t mangle -j NFQUEUE --queue-num %s" % q_num0) 
       if (q_num1 >= 1):
-        os.system("iptables -D OUTPUT -p TCP --syn -j NFQUEUE --queue-num %s" % q_num1) 
+        os.system("iptables -D OUTPUT -t mangle -p TCP --syn -j NFQUEUE --queue-num %s" % q_num1) 
       print " [+] Active queues removed"
       print " [+] Exiting OSfooler..."
       #for p in multiprocessing.active_children():

--- a/osfooler_ng/osfooler_ng.py
+++ b/osfooler_ng/osfooler_ng.py
@@ -546,7 +546,7 @@ def search_os(search_string):
     # Search p0f database
     db = module_p0f.p0f_kdb.get_base()
     p0f_values = []
-    for i in range(0, 250):
+    for i in range(0, len(db)):
       if (re.search(search_string, db[i][6], re.IGNORECASE) or re.search(search_string, db[i][7], re.IGNORECASE)) :
         p0f_values.append("OS: \"" + db[i][6] + "\" DETAILS: \"" + db[i][7] + "\"")
     # Print results
@@ -873,7 +873,7 @@ def main():
   if opts.p0f:
     print("Please, select p0f OS Genre and Details")
     db = module_p0f.p0f_kdb.get_base()
-    for i in range(0, 250):
+    for i in range(0, len(db)):
       print "\tOS Genre=\"%s\" Details=\"%s\"" % (db[i][6], db[i][7])
     exit(0)
 
@@ -927,16 +927,17 @@ def main():
     print " [+] Mutating to p0f:"
     db = module_p0f.p0f_kdb.get_base()
     exists = 0
+    db_size = len(db)
     if (opts.osgenre == "random"):
-      rand_os = randint(0,250)
+      rand_os = randint(0,db_size)
       opts.osgenre = db[rand_os][6]
     if (not opts.details_p0f):
-      for i in range(0, 250):
+      for i in range(0, db_size):
         if (db[i][6] == opts.osgenre):
           print "      WWW:%s|TTL:%s|D:%s|SS:%s|OOO:%s|QQ:%s|OS:%s|DETAILS:%s" % (db[i][0],db[i][1],db[i][2],db[i][3],db[i][4],db[i][5],db[i][6],db[i][7])
           exists = 1
     if (opts.details_p0f):
-      for i in range(0, 250):
+      for i in range(0, db_size):
         if (db[i][6] == opts.osgenre and db[i][7] == opts.details_p0f):
           print "      WWW:%s|TTL:%s|D:%s|SS:%s|OOO:%s|QQ:%s|OS:%s|DETAILS:%s" % (db[i][0],db[i][1],db[i][2],db[i][3],db[i][4],db[i][5],db[i][6],db[i][7])
           exists = 1


### PR DESCRIPTION
Add Netfilter queue maxlen in NetfilterQueue.bind().

It is need for to correct packet loss, if in dmesg  you have messages e.g.:
> [  +0.001304] nfnetlink_queue: nf_queue: full at 1024 entries, dropping packets(s)

https://github.com/ormus112/OSfooler-ng/commit/27692c3166854e07952589270c67a34bf702592f